### PR TITLE
fix: Remove the deprecation use of ioutil

### DIFF
--- a/dubbogo/simple/bestdo/test/pixiu_test.go
+++ b/dubbogo/simple/bestdo/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,7 +64,7 @@ func TestPost2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -83,6 +83,6 @@ func TestPost3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/body/test/pixiu_test.go
+++ b/dubbogo/simple/body/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -40,7 +40,7 @@ func TestPost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "{\"age\":99,\"code\":3,\"iD\":\"0003\",\"name\":\"dubbogo\"}", string(s))
 }
 
@@ -55,7 +55,7 @@ func TestPut1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -70,6 +70,6 @@ func TestPut2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }

--- a/dubbogo/simple/csrf/test/pixiu_test.go
+++ b/dubbogo/simple/csrf/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package csrf
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,7 +41,7 @@ func GetToken(t *testing.T) bool {
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.NotNil(t, resp)
-		s, _ := ioutil.ReadAll(resp.Body)
+		s, _ := io.ReadAll(resp.Body)
 		token = string(s)
 	})
 }
@@ -58,7 +58,7 @@ func TestCsrfHeader(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.NotNil(t, resp)
-		s, _ := ioutil.ReadAll(resp.Body)
+		s, _ := io.ReadAll(resp.Body)
 		t.Log(string(s))
 		assert.True(t, strings.Contains(string(s), "success"))
 	}
@@ -75,7 +75,7 @@ func TestCsrfQuery(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.NotNil(t, resp)
-		s, _ := ioutil.ReadAll(resp.Body)
+		s, _ := io.ReadAll(resp.Body)
 		t.Log(string(s))
 		assert.True(t, strings.Contains(string(s), "success"))
 	}

--- a/dubbogo/simple/direct/test/pixiu_test.go
+++ b/dubbogo/simple/direct/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,7 +64,7 @@ func TestPost2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -83,6 +83,6 @@ func TestPost3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/jaeger/test/pixiu_test.go
+++ b/dubbogo/simple/jaeger/test/pixiu_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -83,7 +82,7 @@ func TestPost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "{\"age\":99,\"code\":4,\"iD\":\"0003\",\"name\":\"dubbogo2\"}", string(s))
 }
 

--- a/dubbogo/simple/jwt/test/pixiu_test.go
+++ b/dubbogo/simple/jwt/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package jwt
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -75,7 +75,7 @@ func verify(t *testing.T, url string, status int) string {
 	assert.NoError(t, err)
 	assert.Equal(t, status, resp.StatusCode)
 	assert.NotNil(t, resp)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	t.Log(string(s))
 	return string(s)
 }

--- a/dubbogo/simple/mix/test/pixiu_test.go
+++ b/dubbogo/simple/mix/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -38,7 +38,7 @@ func TestGet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -53,7 +53,7 @@ func TestPut1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -68,6 +68,6 @@ func TestPut2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }

--- a/dubbogo/simple/nacos/test/pixiu_test.go
+++ b/dubbogo/simple/nacos/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,6 +45,6 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/prometheus/test/pixiu_test.go
+++ b/dubbogo/simple/prometheus/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package prometheus
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -35,7 +35,7 @@ type _testMetric struct {
 
 func (tt *_testMetric) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
-	tt.buf, _ = ioutil.ReadAll(request.Body)
+	tt.buf, _ = io.ReadAll(request.Body)
 	//fmt.Printf("read (%d, content-length: %d) => %s\n", len(tt.buf), request.ContentLength, tt.buf)
 	writer.WriteHeader(200)
 }
@@ -74,7 +74,7 @@ func verify(t *testing.T, url string, status int) string {
 	assert.NoError(t, err)
 	assert.Equal(t, status, resp.StatusCode)
 	assert.NotNil(t, resp)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	t.Log(string(s))
 	return string(s)
 }

--- a/dubbogo/simple/proxy/test/pixiu_test.go
+++ b/dubbogo/simple/proxy/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -40,7 +40,7 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -55,7 +55,7 @@ func TestPost2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -70,6 +70,6 @@ func TestPost3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/query/test/pixiu_test.go
+++ b/dubbogo/simple/query/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -38,7 +38,7 @@ func TestGet1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -51,7 +51,7 @@ func TestGet2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,6 +64,6 @@ func TestGet3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/resolve/test/pixiu_test.go
+++ b/dubbogo/simple/resolve/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,7 +64,7 @@ func TestPost2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -83,6 +83,6 @@ func TestPost3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/traffic/test/pixiu_test.go
+++ b/dubbogo/simple/traffic/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -39,7 +39,7 @@ func TestCanaryGET(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v1"`))
 }
 
@@ -52,7 +52,7 @@ func TestCanaryGET1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v2"`))
 }
 
@@ -66,7 +66,7 @@ func TestCanaryGET2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v3"`))
 }
 
@@ -80,7 +80,7 @@ func TestHeaderGET1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v1"`))
 }
 
@@ -94,7 +94,7 @@ func TestHeaderGET2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v2"`))
 }
 
@@ -108,6 +108,6 @@ func TestHeaderGET3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), `"server": "v3"`))
 }

--- a/dubbogo/simple/triple/test/pixiu_test.go
+++ b/dubbogo/simple/triple/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,6 +43,6 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "Hello test"))
 }

--- a/dubbogo/simple/uri/test/pixiu_test.go
+++ b/dubbogo/simple/uri/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -38,7 +38,7 @@ func TestGet1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -51,7 +51,7 @@ func TestGet2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,6 +64,6 @@ func TestGet3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbogo/simple/zookeeper/test/pixiu_test.go
+++ b/dubbogo/simple/zookeeper/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,6 +43,6 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -38,7 +38,7 @@ func main() {
 func user(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case constant.Post:
-		byts, err := ioutil.ReadAll(r.Body)
+		byts, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.Write([]byte(err.Error()))
 		}

--- a/dubbohttpproxy/test/http2dubbo_test.go
+++ b/dubbohttpproxy/test/http2dubbo_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -45,7 +45,7 @@ func TestPost1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }
 
@@ -64,7 +64,7 @@ func TestPost2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "true", string(s))
 }
 
@@ -83,6 +83,6 @@ func TestPost3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 }

--- a/http/grpc/test/pixiu_test.go
+++ b/http/grpc/test/pixiu_test.go
@@ -20,7 +20,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -46,7 +46,7 @@ func TestGet(t *testing.T) {
 	assert.NoError(t, err)
 	resp, err := c.Do(req)
 	assert.NoError(t, err)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NotNil(t, body)
 	var r proto.GetUserResponse
@@ -66,7 +66,7 @@ func TestPost(t *testing.T) {
 	assert.NoError(t, err)
 	resp, err := c.Do(req)
 	assert.NoError(t, err)
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(t, err)
 	assert.NotNil(t, body)
 	var r proto.GetUserResponse

--- a/http/simple/server/app/server.go
+++ b/http/simple/server/app/server.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -39,7 +39,7 @@ func main() {
 func user(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case constant.Post:
-		byts, err := ioutil.ReadAll(r.Body)
+		byts, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.Write([]byte(err.Error()))
 		}

--- a/http/simple/test/pixiu_test.go
+++ b/http/simple/test/pixiu_test.go
@@ -18,7 +18,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,7 +43,7 @@ func TestPost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "dubbogo"))
 	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
 	assert.Equal(t, "api.dubbo.com", ao)
@@ -60,7 +60,7 @@ func TestGET1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
-	s, _ := ioutil.ReadAll(resp.Body)
+	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
 	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
 	assert.Equal(t, "api.dubbo.com", ao)

--- a/xds/dubbo-go-istio/server/go.mod
+++ b/xds/dubbo-go-istio/server/go.mod
@@ -1,6 +1,8 @@
 module dubbo-go-app
 
-go 1.18
+go 1.23.0
+
+toolchain go1.23.8
 
 require (
 	dubbo.apache.org/dubbo-go/v3 v3.1.1-rc1

--- a/xds/filesystem-control-panel/server/main.go
+++ b/xds/filesystem-control-panel/server/main.go
@@ -20,7 +20,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -129,7 +128,7 @@ func main() {
 }
 
 func GenerateSnapshotPixiuFromFile() *cache.Snapshot {
-	cdsStr, err := ioutil.ReadFile("../pixiu/cds.json")
+	cdsStr, err := os.ReadFile("../pixiu/cds.json")
 	if err != nil {
 		l.Errorf("%s", err)
 	}
@@ -139,7 +138,7 @@ func GenerateSnapshotPixiuFromFile() *cache.Snapshot {
 		l.Errorf("%s", err)
 	}
 
-	ldsStr, err := ioutil.ReadFile("../pixiu/lds.json")
+	ldsStr, err := os.ReadFile("../pixiu/lds.json")
 	if err != nil {
 		l.Errorf("%s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

`io/ioutil` is now deprecated, use `io` or `os` as replacment