### PR TITLE
fix: fix prometheus test sometimes fails bug

### DIFF
--- a/dubbogo/simple/prometheus/test/pixiu_test.go
+++ b/dubbogo/simple/prometheus/test/pixiu_test.go
@@ -18,6 +18,7 @@
 package prometheus
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -68,7 +69,7 @@ func TestLocal(t *testing.T) {
 
 	go func() {
 		server := &http.Server{Addr: ":9091", Handler: metricServer}
-		defer server.Close()
+		server.Shutdown(context.Background())
 		server.ListenAndServe()
 	}()
 


### PR DESCRIPTION
old test sometimes may fail because data race, this pr refactor test metrics handling and add metric channel for improved synchronization