### PR TITLE
feat: Add OPA filter sample

### DIFF
--- a/dubbogo/simple/opa/docker/docker-compose.yml
+++ b/dubbogo/simple/opa/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: '3'
+
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - 2181:2181
+    restart: on-failure

--- a/dubbogo/simple/opa/pixiu/conf.yaml
+++ b/dubbogo/simple/opa/pixiu/conf.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+static_resources:
+  listeners:
+    - name: "net/http"
+      protocol_type: "HTTP"
+      address:
+        socket_address:
+          address: "0.0.0.0"
+          port: 8888
+      filter_chains:
+        filters:
+          - name: dgp.filter.httpconnectionmanager
+            config:
+              route_config:
+                routes:
+                  - match:
+                      prefix: "/UserService"
+                    route:
+                      cluster: "user"
+                      cluster_not_found_response_code: 505
+                  - match:
+                      prefix: "/OtherService"
+                    route:
+                      cluster: "user"
+                      cluster_not_found_response_code: 505
+              http_filters:
+                - name: dgp.filter.http.opa
+                  config:
+                    policy: |
+                      package pixiu
+                      import future.keywords.if
+                      default allow := false
+
+                      allow if {
+                        input.path == "/UserService"
+                        input.headers["Test_header"][0] == "1"
+                      }
+                    entrypoint: data.pixiu.allow
+                - name: dgp.filter.http.httpproxy
+                  config:
+
+      config:
+        idle_timeout: 5s
+        read_timeout: 5s
+        write_timeout: 5s
+  clusters:
+    - name: "user"
+      lb_policy: "lb"
+      endpoints:
+        - id: 1
+          socket_address:
+            address: 127.0.0.1
+            port: 1314
+  shutdown_config:
+    timeout: "60s"
+    step_timeout: "10s"
+    reject_policy: "immediacy"

--- a/dubbogo/simple/opa/server/server.go
+++ b/dubbogo/simple/opa/server/server.go
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type Resp struct {
+	Message string `json:"message"`
+	Result  string `json:"result"`
+}
+
+func main() {
+	routers := []string{"/UserService", "/OtherService"}
+
+	for _, rt := range routers {
+		route := rt
+		msg := route[strings.LastIndex(route, "/")+1:]
+
+		http.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+			// 打印日志，显示后端接收到的请求
+			log.Printf("[backend] %s %s Headers=%v", r.Method, r.URL.Path, r.Header)
+
+			// 返回 JSON
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(Resp{
+				Message: msg,
+				Result:  "pass",
+			})
+		})
+	}
+
+	log.Println("Starting sample server on :1314 ...")
+	log.Fatal(http.ListenAndServe(":1314", nil))
+}

--- a/dubbogo/simple/opa/test/pixiv_test.go
+++ b/dubbogo/simple/opa/test/pixiv_test.go
@@ -1,0 +1,68 @@
+package test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserServiceAllow(t *testing.T) {
+	url := "http://localhost:8888/UserService"
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+
+	// Must add header to pass OPA
+	req.Header.Set("Test_header", "1")
+
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	// OPA allows -> backend returns "pass" JSON
+	assert.True(t, strings.Contains(string(body), "pass"))
+	assert.True(t, strings.Contains(string(body), "UserService"))
+}
+
+func TestUserServiceDeny(t *testing.T) {
+	url := "http://localhost:8888/UserService"
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+
+	// No header -> should be denied (null)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "null", strings.TrimSpace(string(body)))
+}
+
+func TestOtherServiceDeny(t *testing.T) {
+	url := "http://localhost:8888/OtherService"
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest("GET", url, nil)
+	assert.NoError(t, err)
+
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	// Expected null because OPA has no allow rule for /OtherService
+	assert.Equal(t, "null", strings.TrimSpace(string(body)))
+}


### PR DESCRIPTION
**What this PR does**:
This PR adds a new sample for using the Open Policy Agent (OPA) filter in dubbo-go-pixiu. It provides a complete and runnable example demonstrating how to implement request authorization and policy enforcement using OPA, ensuring that only requests that meet specific criteria are forwarded to the backend service.

For a detailed guide on how to use and configure this filter, please refer to the dubbo-go-pixiu/docs directory.
