### PR TITLE
chore: rename constant.HeaderKeyContextType

### DIFF
--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -50,14 +50,14 @@ func user(w http.ResponseWriter, r *http.Request) {
 		}
 		_, ok := cache.Get(name)
 		if ok {
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+			w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 			w.Write([]byte("{\"message\":\"data is exist\"}"))
 			return
 		}
 		user.ID = randSeq(5)
 		if cache.Add(&user) {
 			b, _ := json.Marshal(&user)
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+			w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 			w.Write(b)
 			return
 		}

--- a/http/simple/server/app/server.go
+++ b/http/simple/server/app/server.go
@@ -50,14 +50,14 @@ func user(w http.ResponseWriter, r *http.Request) {
 		}
 		_, ok := cache.Get(user.Name)
 		if ok {
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+			w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 			w.Write([]byte("{\"message\":\"data is exist\"}"))
 			return
 		}
 		user.ID = randSeq(5)
 		if cache.Add(&user) {
 			b, _ := json.Marshal(&user)
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+			w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 			w.Write(b)
 			return
 		}
@@ -77,7 +77,7 @@ func user(w http.ResponseWriter, r *http.Request) {
 		// w.WriteHeader(200)
 		if b {
 			b, _ := json.Marshal(u)
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+			w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 			w.Write(b)
 			return
 		}

--- a/plugins/ratelimit/server/app/server.go
+++ b/plugins/ratelimit/server/app/server.go
@@ -36,7 +36,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case constant.Get:
 		// w.WriteHeader(200)
-		w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+		w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("resp"))
 	}

--- a/shutdown/dubbo/server/app/server.go
+++ b/shutdown/dubbo/server/app/server.go
@@ -35,6 +35,6 @@ func main() {
 
 func testFunc(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(3 * time.Second)
-	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+	w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 	w.Write([]byte("{\"message\":\"receive\"}"))
 }

--- a/shutdown/http/server/app/server.go
+++ b/shutdown/http/server/app/server.go
@@ -35,6 +35,6 @@ func main() {
 
 func testFunc(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(3 * time.Second)
-	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+	w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 	w.Write([]byte("{\"message\":\"receive\"}"))
 }

--- a/shutdown/triple/server/app/server.go
+++ b/shutdown/triple/server/app/server.go
@@ -33,6 +33,6 @@ func main() {
 
 func testFunc(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(3 * time.Second)
-	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+	w.Header().Set("Content-Type", constant.HeaderValueJsonUtf8)
 	w.Write([]byte("{\"message\":\"receive\"}"))
 }


### PR DESCRIPTION
constant.HeaderKeyContextType in dubbo-go-pixiu need to be renamed to constant.HeaderKeyContentType if samples still use this const may result in ci fail, so need to rename it