### PR TITLE
fix: complete and align HTTPS sample chain

### DIFF
--- a/https/docker/docker-compose.yml
+++ b/https/docker/docker-compose.yml
@@ -1,0 +1,87 @@
+#
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+services:
+  zookeeper:
+    image: zookeeper
+    ports:
+      - 2181:2181
+    restart: on-failure
+
+  pixiu-cert-init:
+    image: alpine:latest
+    user: "root"
+    command:
+      - sh
+      - -c
+      - |
+        apk add --no-cache openssl &&
+        openssl req -x509 -nodes \
+          -newkey ec -pkeyopt ec_paramgen_curve:P-256 \
+          -keyout /tmp/k.pem -out /tmp/c.pem \
+          -days 365 \
+          -subj '/CN=sample.domain.com' \
+          -addext 'subjectAltName=DNS:sample.domain.com' \
+          -addext 'extendedKeyUsage=serverAuth' &&
+        cat /tmp/k.pem /tmp/c.pem > /cache/sample.domain.com &&
+        chmod 644 /cache/sample.domain.com
+    volumes:
+      - cert-cache:/cache
+
+  provider:
+    image: golang:1.25.4-bookworm
+    working_dir: /workspace
+    command: go run ./https/server/app
+    environment:
+      - DUBBO_GO_CONFIG_PATH=/etc/dubbo/server.yml
+      - APP_LOG_CONF_FILE=/etc/dubbo/log.yml
+    volumes:
+      - ../..:/workspace:ro
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+      - ../server/profiles/dev/server.yml:/etc/dubbo/server.yml:ro
+      - ../server/profiles/dev/log.yml:/etc/dubbo/log.yml:ro
+    depends_on:
+      - zookeeper
+
+  pixiu:
+    platform: linux/amd64
+    build:
+      context: https://github.com/apache/dubbo-go-pixiu.git#v1.1.0
+    user: "root"
+    environment:
+      - XDG_CACHE_HOME=/var/cache
+    ports:
+      - 8443:443
+    volumes:
+      - cert-cache:/var/cache/golang-autocert
+      - ../pixiu/conf.yaml:/etc/pixiu/conf.yaml:ro
+      - ../pixiu/api_config.yaml:/etc/pixiu/api_config.yaml:ro
+    depends_on:
+      pixiu-cert-init:
+        condition: service_completed_successfully
+      provider:
+        condition: service_started
+      zookeeper:
+        condition: service_started
+
+volumes:
+  cert-cache:
+  go-mod-cache:
+  go-build-cache:

--- a/https/pixiu/api_config.yaml
+++ b/https/pixiu/api_config.yaml
@@ -19,7 +19,7 @@
 name: pixiu
 description: pixiu sample
 resources:
-  - path: '/api/v1/test-dubbo/:application/:interface'
+  - path: '/api/v1/test-dubbo/:interface'
     type: restful
     description: common
     methods:
@@ -35,8 +35,6 @@ resources:
               mapTo: opt.values
             - name: requestBody.types
               mapTo: opt.types
-            - name: uri.application
-              mapTo: opt.application
             - name: uri.interface
               mapTo: opt.interface
             - name: queryStrings.method

--- a/https/pixiu/conf.yaml
+++ b/https/pixiu/conf.yaml
@@ -27,7 +27,7 @@ static_resources:
             - "sample.domain.com"
             - "sample.domain-1.com"
             - "sample.domain-2.com"
-          certs_dir: $PROJECT_DIR/cert
+          certs_dir: /var/cache/golang-autocert
       filter_chains:
           filters:
             - name: dgp.filter.httpconnectionmanager
@@ -37,12 +37,12 @@ static_resources:
                     - match:
                         prefix: "/api/v1"
                       route:
-                        cluster: "test-dubbo"
+                        cluster: "test_dubbo"
                         cluster_not_found_response_code: 505
                 http_filters:
                   - name: dgp.filter.http.apiconfig
                     config:
-                      path: $PROJECT_DIR/pixiu/api_config.yaml
+                      path: /etc/pixiu/api_config.yaml
                   - name: dgp.filter.http.dubboproxy
                     config:
                       dubboProxyConfig:
@@ -50,7 +50,7 @@ static_resources:
                           "zookeeper":
                             protocol: "zookeeper"
                             timeout: "3s"
-                            address: "127.0.0.1:2181"
+                            address: "zookeeper:2181"
                             username: ""
                             password: ""
                         timeout_config:
@@ -64,13 +64,14 @@ static_resources:
         read_timeout: 5s
         write_timeout: 5s
   clusters:
-    - name: "user"
-      lb_policy: "lb"
-      endpoints:
-        - id: 1
-          socket_address:
-            address: 127.0.0.1
-            port: 1314
+    - name: "test_dubbo"
+      lb_policy: "RoundRobin"
+      registries:
+        "zookeeper":
+          timeout: "3s"
+          address: "zookeeper:2181"
+          username: ""
+          password: ""
   shutdown_config:
     timeout: "60s"
     step_timeout: "10s"

--- a/https/request.sh
+++ b/https/request.sh
@@ -22,12 +22,12 @@ ADDRESS="https://${DOMAIN}:${PORT}"
 RESOLVE="${DOMAIN}:${PORT}:127.0.0.1"
 
 API1=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=GetUserByName" -d '{"types":"string","values":"tc"}' --header 'Content-Type: application/json')
-API2=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=UpdateUserByName" -d '{"types":"string, object","values":["tc",{"id":"0001","code":1,"name":"tc","age":15}]}' --header "Content-Type: application/json")
+API2=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=UpdateUserByName" -d '{"types":"string,object","values":["tc",{"id":"0001","code":1,"name":"tc","age":15}]}' --header "Content-Type: application/json")
 API3=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=GetUserByCode" -d '{"types":"int","values":1}' --header "Content-Type: application/json")
 
-ARRAY_API=(${API1} ${API2} ${API3})
+ARRAY_API=("${API1}" "${API2}" "${API3}")
 
-for element in ${ARRAY_API[@]}
+for element in "${ARRAY_API[@]}"
 do
-echo ${element}
+echo "${element}"
 done

--- a/https/request.sh
+++ b/https/request.sh
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+DOMAIN="sample.domain.com"
+PORT="8443"
+ADDRESS="https://${DOMAIN}:${PORT}"
+RESOLVE="${DOMAIN}:${PORT}:127.0.0.1"
+
+API1=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=GetUserByName" -d '{"types":"string","values":"tc"}' --header 'Content-Type: application/json')
+API2=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=UpdateUserByName" -d '{"types":"string, object","values":["tc",{"id":"0001","code":1,"name":"tc","age":15}]}' --header "Content-Type: application/json")
+API3=$(curl -k --resolve "${RESOLVE}" -s -X POST "${ADDRESS}/api/v1/test-dubbo/com.dubbogo.pixiu.UserService?group=test&version=1.0.0&method=GetUserByCode" -d '{"types":"int","values":1}' --header "Content-Type: application/json")
+
+ARRAY_API=(${API1} ${API2} ${API3})
+
+for element in ${ARRAY_API[@]}
+do
+echo ${element}
+done

--- a/https/server/app/server.go
+++ b/https/server/app/server.go
@@ -34,13 +34,11 @@ import (
 
 var survivalTimeout = int(3e9)
 
-// they are necessary:
-// export DUBBO_GO_CONFIG_PATH="../profiles/dev/server.yml"
-// export APP_LOG_CONF_FILE="../profiles/dev/log.yml"
 func main() {
 	if err := dubbo.Load(); err != nil {
 		panic(err)
 	}
+	logger.Infof("dubbo version is: %s", Version)
 	initSignal()
 }
 

--- a/https/server/app/server.go
+++ b/https/server/app/server.go
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3"
+	_ "dubbo.apache.org/dubbo-go/v3/imports"
+
+	"github.com/dubbogo/gost/log/logger"
+)
+
+var survivalTimeout = int(3e9)
+
+// they are necessary:
+// export DUBBO_GO_CONFIG_PATH="../profiles/dev/server.yml"
+// export APP_LOG_CONF_FILE="../profiles/dev/log.yml"
+func main() {
+	if err := dubbo.Load(); err != nil {
+		panic(err)
+	}
+	initSignal()
+}
+
+func initSignal() {
+	signals := make(chan os.Signal, 1)
+	// It is not possible to block SIGKILL or syscall.SIGSTOP
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
+	for {
+		sig := <-signals
+		logger.Infof("get signal %s", sig.String())
+		switch sig {
+		case syscall.SIGHUP:
+			// reload()
+		default:
+			time.AfterFunc(time.Duration(survivalTimeout), func() {
+				logger.Warnf("app exit now by force...")
+				os.Exit(1)
+			})
+
+			// The program exits normally or timeout forcibly exits.
+			fmt.Println("provider app exit now...")
+			return
+		}
+	}
+}

--- a/https/server/app/user.go
+++ b/https/server/app/user.go
@@ -161,7 +161,7 @@ type UserProvider struct{}
 
 // CreateUser new user, PX config POST.
 func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error) {
-	fmt.Printf("Req CreateUser data: %#v \n", user)
+	outLn("Req CreateUser data:%#v", user)
 	if user == nil {
 		return nil, errors.New("not found")
 	}
@@ -180,10 +180,10 @@ func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error
 
 // GetUserByName query by name, single param, PX config GET.
 func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, error) {
-	fmt.Printf("Req GetUserByName name: %#v \n", name)
+	outLn("Req GetUserByName name:%#v", name)
 	r, ok := cache.GetByName(name)
 	if ok {
-		fmt.Printf("Req GetUserByName result: %#v \n", r)
+		outLn("Req GetUserByName result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -191,10 +191,10 @@ func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, e
 
 // GetUserByCode query by code, single param, PX config GET.
 func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, error) {
-	fmt.Printf("Req GetUserByCode name: %#v \n", code)
+	outLn("Req GetUserByCode name:%#v", code)
 	r, ok := cache.GetByCode(code)
 	if ok {
-		fmt.Printf("Req GetUserByCode result: %#v \n", r)
+		outLn("Req GetUserByCode result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -202,12 +202,12 @@ func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, er
 
 // GetUserTimeout query by name, will timeout for pixiu.
 func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, error) {
-	fmt.Printf("Req GetUserByName name: %#v \n", name)
+	outLn("Req GetUserByName name:%#v", name)
 	// sleep 10s, pixiu config less than 10s.
 	time.Sleep(10 * time.Second)
 	r, ok := cache.GetByName(name)
 	if ok {
-		fmt.Printf("Req GetUserByName result: %#v \n", r)
+		outLn("Req GetUserByName result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -215,10 +215,10 @@ func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, 
 
 // GetUserByNameAndAge query by name and age, two params, PX config GET.
 func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age int32) (*User, error) {
-	fmt.Printf("Req GetUserByNameAndAge name: %s, age: %d \n", name, age)
+	outLn("Req GetUserByNameAndAge name:%s, age:%d", name, age)
 	r, ok := cache.GetByName(name)
 	if ok && r.Age == age {
-		fmt.Printf("Req GetUserByNameAndAge result: %#v \n", r)
+		outLn("Req GetUserByNameAndAge result:%#v", r)
 		return r, nil
 	}
 	return r, nil
@@ -226,7 +226,7 @@ func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age
 
 // UpdateUser update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error) {
-	fmt.Printf("Req UpdateUser data: %#v \n", user)
+	outLn("Req UpdateUser data:%#v", user)
 	r, ok := cache.GetByName(user.Name)
 	if ok {
 		if user.ID != "" {
@@ -242,7 +242,7 @@ func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error)
 
 // UpdateUserByName update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUserByName(ctx context.Context, name string, user *User) (bool, error) {
-	fmt.Printf("Req UpdateUserByName data: %#v \n", user)
+	outLn("Req UpdateUserByName data:%#v", user)
 	r, ok := cache.GetByName(name)
 	if ok {
 		if user.ID != "" {
@@ -264,4 +264,9 @@ func (u *UserProvider) Reference() string {
 // nolint
 func (u User) JavaClassName() string {
 	return "com.dubbogo.pixiu.User"
+}
+
+// nolint
+func outLn(format string, args ...interface{}) {
+	fmt.Printf("\033[32;40m"+format+"\033[0m\n", args...)
 }

--- a/https/server/app/user.go
+++ b/https/server/app/user.go
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3"
+
+	hessian "github.com/apache/dubbo-go-hessian2"
+)
+
+func init() {
+	dubbo.SetProviderService(new(UserProvider))
+	// ------for hessian2------
+	hessian.RegisterPOJO(&User{})
+
+	cache = newUserDB()
+
+	t1, _ := time.Parse(
+		time.RFC3339,
+		"2021-08-01T10:08:41+00:00")
+
+	cache.Add(&User{ID: "0001", Code: 1, Name: "tc", Age: 18, Time: t1})
+	cache.Add(&User{ID: "0002", Code: 2, Name: "ic", Age: 88, Time: t1})
+}
+
+var cache *userDB
+
+// userDB cache user.
+type userDB struct {
+	// key is name, value is user obj
+	nameIndex map[string]*User
+	// key is code, value is user obj
+	codeIndex map[int64]*User
+	lock      sync.Mutex
+}
+
+// userDB create func
+func newUserDB() *userDB {
+	return &userDB{
+		nameIndex: make(map[string]*User, 16),
+		codeIndex: make(map[int64]*User, 16),
+		lock:      sync.Mutex{},
+	}
+}
+
+// nolint
+func (db *userDB) Add(u *User) bool {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if u.Name == "" || u.Code <= 0 {
+		return false
+	}
+
+	if !db.existName(u.Name) && !db.existCode(u.Code) {
+		return db.AddForName(u) && db.AddForCode(u)
+	}
+
+	return false
+}
+
+// nolint
+func (db *userDB) AddForName(u *User) bool {
+	if len(u.Name) == 0 {
+		return false
+	}
+
+	if _, ok := db.nameIndex[u.Name]; ok {
+		return false
+	}
+
+	db.nameIndex[u.Name] = u
+	return true
+}
+
+// nolint
+func (db *userDB) AddForCode(u *User) bool {
+	if u.Code <= 0 {
+		return false
+	}
+
+	if _, ok := db.codeIndex[u.Code]; ok {
+		return false
+	}
+
+	db.codeIndex[u.Code] = u
+	return true
+}
+
+// nolint
+func (db *userDB) GetByName(n string) (*User, bool) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	r, ok := db.nameIndex[n]
+	return r, ok
+}
+
+// nolint
+func (db *userDB) GetByCode(n int64) (*User, bool) {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	r, ok := db.codeIndex[n]
+	return r, ok
+}
+
+func (db *userDB) existName(name string) bool {
+	if len(name) <= 0 {
+		return false
+	}
+
+	_, ok := db.nameIndex[name]
+	return ok
+}
+
+func (db *userDB) existCode(code int64) bool {
+	if code <= 0 {
+		return false
+	}
+
+	_, ok := db.codeIndex[code]
+	return ok
+}
+
+// User user obj.
+type User struct {
+	ID   string    `json:"id,omitempty"`
+	Code int64     `json:"code,omitempty"`
+	Name string    `json:"name,omitempty"`
+	Age  int32     `json:"age,omitempty"`
+	Time time.Time `json:"time,omitempty"`
+}
+
+// UserProvider the dubbo provider.
+// like: version: 1.0.0 group: test
+type UserProvider struct{}
+
+// CreateUser new user, PX config POST.
+func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error) {
+	fmt.Printf("Req CreateUser data: %#v \n", user)
+	if user == nil {
+		return nil, errors.New("not found")
+	}
+	_, ok := cache.GetByName(user.Name)
+	if ok {
+		return nil, errors.New("data is exist")
+	}
+
+	b := cache.Add(user)
+	if b {
+		return user, nil
+	}
+
+	return nil, errors.New("add error")
+}
+
+// GetUserByName query by name, single param, PX config GET.
+func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, error) {
+	fmt.Printf("Req GetUserByName name: %#v \n", name)
+	r, ok := cache.GetByName(name)
+	if ok {
+		fmt.Printf("Req GetUserByName result: %#v \n", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserByCode query by code, single param, PX config GET.
+func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, error) {
+	fmt.Printf("Req GetUserByCode name: %#v \n", code)
+	r, ok := cache.GetByCode(code)
+	if ok {
+		fmt.Printf("Req GetUserByCode result: %#v \n", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserTimeout query by name, will timeout for pixiu.
+func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, error) {
+	fmt.Printf("Req GetUserByName name: %#v \n", name)
+	// sleep 10s, pixiu config less than 10s.
+	time.Sleep(10 * time.Second)
+	r, ok := cache.GetByName(name)
+	if ok {
+		fmt.Printf("Req GetUserByName result: %#v \n", r)
+		return r, nil
+	}
+	return nil, nil
+}
+
+// GetUserByNameAndAge query by name and age, two params, PX config GET.
+func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age int32) (*User, error) {
+	fmt.Printf("Req GetUserByNameAndAge name: %s, age: %d \n", name, age)
+	r, ok := cache.GetByName(name)
+	if ok && r.Age == age {
+		fmt.Printf("Req GetUserByNameAndAge result: %#v \n", r)
+		return r, nil
+	}
+	return r, nil
+}
+
+// UpdateUser update by user struct, my be another struct, PX config POST or PUT.
+func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error) {
+	fmt.Printf("Req UpdateUser data: %#v \n", user)
+	r, ok := cache.GetByName(user.Name)
+	if ok {
+		if user.ID != "" {
+			r.ID = user.ID
+		}
+		if user.Age >= 0 {
+			r.Age = user.Age
+		}
+		return true, nil
+	}
+	return false, errors.New("not found")
+}
+
+// UpdateUserByName update by user struct, my be another struct, PX config POST or PUT.
+func (u *UserProvider) UpdateUserByName(ctx context.Context, name string, user *User) (bool, error) {
+	fmt.Printf("Req UpdateUserByName data: %#v \n", user)
+	r, ok := cache.GetByName(name)
+	if ok {
+		if user.ID != "" {
+			r.ID = user.ID
+		}
+		if user.Age >= 0 {
+			r.Age = user.Age
+		}
+		return true, nil
+	}
+	return false, errors.New("not found")
+}
+
+// nolint
+func (u *UserProvider) Reference() string {
+	return "com.dubbogo.pixiu.UserService"
+}
+
+// nolint
+func (u User) JavaClassName() string {
+	return "com.dubbogo.pixiu.User"
+}

--- a/https/server/app/user.go
+++ b/https/server/app/user.go
@@ -116,7 +116,14 @@ func (db *userDB) GetByName(n string) (*User, bool) {
 	defer db.lock.Unlock()
 
 	r, ok := db.nameIndex[n]
-	return r, ok
+
+	if !ok {
+		return nil, false
+	}
+
+	copyUser := *r
+
+	return &copyUser, ok
 }
 
 // nolint
@@ -125,7 +132,14 @@ func (db *userDB) GetByCode(n int64) (*User, bool) {
 	defer db.lock.Unlock()
 
 	r, ok := db.codeIndex[n]
-	return r, ok
+
+	if !ok {
+		return nil, false
+	}
+
+	copyUser := *r
+
+	return &copyUser, ok
 }
 
 func (db *userDB) existName(name string) bool {
@@ -144,6 +158,29 @@ func (db *userDB) existCode(code int64) bool {
 
 	_, ok := db.codeIndex[code]
 	return ok
+}
+
+func (db *userDB) UpdateByName(name string, user *User) bool {
+	if user == nil {
+		return false
+	}
+
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	r, ok := db.nameIndex[name]
+	if !ok {
+		return false
+	}
+
+	if user.ID != "" {
+		r.ID = user.ID
+	}
+	if user.Age >= 0 {
+		r.Age = user.Age
+	}
+
+	return true
 }
 
 // User user obj.
@@ -227,14 +264,7 @@ func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age
 // UpdateUser update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error) {
 	outLn("Req UpdateUser data:%#v", user)
-	r, ok := cache.GetByName(user.Name)
-	if ok {
-		if user.ID != "" {
-			r.ID = user.ID
-		}
-		if user.Age >= 0 {
-			r.Age = user.Age
-		}
+	if user != nil && cache.UpdateByName(user.Name, user) {
 		return true, nil
 	}
 	return false, errors.New("not found")
@@ -243,14 +273,7 @@ func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error)
 // UpdateUserByName update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUserByName(ctx context.Context, name string, user *User) (bool, error) {
 	outLn("Req UpdateUserByName data:%#v", user)
-	r, ok := cache.GetByName(name)
-	if ok {
-		if user.ID != "" {
-			r.ID = user.ID
-		}
-		if user.Age >= 0 {
-			r.Age = user.Age
-		}
+	if user != nil && cache.UpdateByName(name, user) {
 		return true, nil
 	}
 	return false, errors.New("not found")

--- a/https/server/app/user.go
+++ b/https/server/app/user.go
@@ -20,7 +20,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 )
@@ -29,6 +28,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
+
+	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {
@@ -198,7 +199,7 @@ type UserProvider struct{}
 
 // CreateUser new user, PX config POST.
 func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error) {
-	outLn("Req CreateUser data:%#v", user)
+	logger.Infof("Req CreateUser data:%#v", user)
 	if user == nil {
 		return nil, errors.New("not found")
 	}
@@ -217,10 +218,10 @@ func (u *UserProvider) CreateUser(ctx context.Context, user *User) (*User, error
 
 // GetUserByName query by name, single param, PX config GET.
 func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, error) {
-	outLn("Req GetUserByName name:%#v", name)
+	logger.Infof("Req GetUserByName name:%#v", name)
 	r, ok := cache.GetByName(name)
 	if ok {
-		outLn("Req GetUserByName result:%#v", r)
+		logger.Infof("Req GetUserByName result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -228,10 +229,10 @@ func (u *UserProvider) GetUserByName(ctx context.Context, name string) (*User, e
 
 // GetUserByCode query by code, single param, PX config GET.
 func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, error) {
-	outLn("Req GetUserByCode name:%#v", code)
+	logger.Infof("Req GetUserByCode name:%#v", code)
 	r, ok := cache.GetByCode(code)
 	if ok {
-		outLn("Req GetUserByCode result:%#v", r)
+		logger.Infof("Req GetUserByCode result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -239,12 +240,12 @@ func (u *UserProvider) GetUserByCode(ctx context.Context, code int64) (*User, er
 
 // GetUserTimeout query by name, will timeout for pixiu.
 func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, error) {
-	outLn("Req GetUserByName name:%#v", name)
+	logger.Infof("Req GetUserByName name:%#v", name)
 	// sleep 10s, pixiu config less than 10s.
 	time.Sleep(10 * time.Second)
 	r, ok := cache.GetByName(name)
 	if ok {
-		outLn("Req GetUserByName result:%#v", r)
+		logger.Infof("Req GetUserByName result:%#v", r)
 		return r, nil
 	}
 	return nil, nil
@@ -252,10 +253,10 @@ func (u *UserProvider) GetUserTimeout(ctx context.Context, name string) (*User, 
 
 // GetUserByNameAndAge query by name and age, two params, PX config GET.
 func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age int32) (*User, error) {
-	outLn("Req GetUserByNameAndAge name:%s, age:%d", name, age)
+	logger.Infof("Req GetUserByNameAndAge name:%s, age:%d", name, age)
 	r, ok := cache.GetByName(name)
 	if ok && r.Age == age {
-		outLn("Req GetUserByNameAndAge result:%#v", r)
+		logger.Infof("Req GetUserByNameAndAge result:%#v", r)
 		return r, nil
 	}
 	return r, nil
@@ -263,7 +264,7 @@ func (u *UserProvider) GetUserByNameAndAge(ctx context.Context, name string, age
 
 // UpdateUser update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error) {
-	outLn("Req UpdateUser data:%#v", user)
+	logger.Infof("Req UpdateUser data:%#v", user)
 	if user != nil && cache.UpdateByName(user.Name, user) {
 		return true, nil
 	}
@@ -272,7 +273,7 @@ func (u *UserProvider) UpdateUser(ctx context.Context, user *User) (bool, error)
 
 // UpdateUserByName update by user struct, my be another struct, PX config POST or PUT.
 func (u *UserProvider) UpdateUserByName(ctx context.Context, name string, user *User) (bool, error) {
-	outLn("Req UpdateUserByName data:%#v", user)
+	logger.Infof("Req UpdateUserByName data:%#v", user)
 	if user != nil && cache.UpdateByName(name, user) {
 		return true, nil
 	}
@@ -287,9 +288,4 @@ func (u *UserProvider) Reference() string {
 // nolint
 func (u User) JavaClassName() string {
 	return "com.dubbogo.pixiu.User"
-}
-
-// nolint
-func outLn(format string, args ...interface{}) {
-	fmt.Printf("\033[32;40m"+format+"\033[0m\n", args...)
 }

--- a/https/server/app/version.go
+++ b/https/server/app/version.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+// Version dubbo version
+const Version = "2.7.5"

--- a/https/server/profiles/dev/log.yml
+++ b/https/server/profiles/dev/log.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+level: "debug"
+development: true
+disableCaller: false
+disableStacktrace: false
+sampling:
+encoding: "console"
+
+# encoder
+encoderConfig:
+  messageKey: "message"
+  levelKey: "level"
+  timeKey: "time"
+  nameKey: "logger"
+  callerKey: "caller"
+  stacktraceKey: "stacktrace"
+  lineEnding: ""
+  levelEncoder: "capitalColor"
+  timeEncoder: "iso8601"
+  durationEncoder: "seconds"
+  callerEncoder: "short"
+  nameEncoder: ""
+
+outputPaths:
+  - "stderr"
+errorOutputPaths:
+  - "stderr"
+initialFields:

--- a/https/server/profiles/dev/server.yml
+++ b/https/server/profiles/dev/server.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# dubbo server yaml configure file
+# application config
+dubbo:
+  registries:
+    zk:
+      protocol: zookeeper
+      timeout: 3s
+      address: zookeeper:2181
+  protocols:
+    dubbo:
+      name: dubbo
+      port: 20000
+  provider:
+    registry-ids: zk
+    services:
+      UserProvider:
+        group: test
+        version: 1.0.0
+        cluster: test_dubbo
+        serialization: hessian2
+        interface: com.dubbogo.pixiu.UserService

--- a/https/test/pixiu_test.go
+++ b/https/test/pixiu_test.go
@@ -75,16 +75,16 @@ func post(t *testing.T, url string, data string) string {
 		req.Header.Add("Content-Type", "application/json")
 
 		resp, err := client.Do(req)
-		if err == nil && resp != nil {
+		if resp != nil {
 			body, _ := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
 			lastBody = string(body)
 			lastStatus = resp.StatusCode
-			if resp.StatusCode == http.StatusOK {
-				return lastBody
-			}
-		} else {
+		}
+		if err != nil {
 			lastErr = err
+		} else if resp != nil && resp.StatusCode == http.StatusOK {
+			return lastBody
 		}
 
 		if time.Now().After(deadline) {

--- a/https/test/pixiu_test.go
+++ b/https/test/pixiu_test.go
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	httpsDomain = "sample.domain.com"
+	httpsPort   = "8443"
+	httpsTarget = "127.0.0.1:" + httpsPort
+	httpsAPI    = "https://" + httpsDomain + ":" + httpsPort + "/api/v1/test-dubbo/com.dubbogo.pixiu.UserService"
+	waitTimeout = 180 * time.Second
+)
+
+func newHTTPSClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if addr == httpsDomain+":"+httpsPort {
+					addr = httpsTarget
+				}
+				return dialer.DialContext(ctx, network, addr)
+			},
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				ServerName:         httpsDomain,
+				InsecureSkipVerify: true, //nolint:gosec
+			},
+		},
+	}
+}
+
+func post(t *testing.T, url string, data string) string {
+	t.Helper()
+
+	client := newHTTPSClient()
+	deadline := time.Now().Add(waitTimeout)
+	var lastBody string
+	var lastErr error
+	var lastStatus int
+
+	for {
+		req, err := http.NewRequest("POST", url, strings.NewReader(data))
+		assert.NoError(t, err)
+		req.Header.Add("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err == nil && resp != nil {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			lastBody = string(body)
+			lastStatus = resp.StatusCode
+			if resp.StatusCode == http.StatusOK {
+				return lastBody
+			}
+		} else {
+			lastErr = err
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	if lastErr != nil {
+		t.Fatalf("request failed: %v", lastErr)
+	}
+	t.Fatalf("unexpected status %d: %s", lastStatus, lastBody)
+	return ""
+}
+
+func TestPost1(t *testing.T) {
+	url := httpsAPI + "?group=test&version=1.0.0&method=GetUserByName"
+	data := "{\"types\":\"string\",\"values\":\"tc\"}"
+	s := post(t, url, data)
+	assert.True(t, strings.Contains(s, "0001"))
+}
+
+func TestPost2(t *testing.T) {
+	url := httpsAPI + "?group=test&version=1.0.0&method=UpdateUserByName"
+	data := "{\"types\":\"string,object\",\"values\":[\"tc\",{\"id\":\"0001\",\"code\":1,\"name\":\"tc\",\"age\":15}]}"
+	s := post(t, url, data)
+	assert.Equal(t, "true", s)
+}
+
+func TestPost3(t *testing.T) {
+	url := httpsAPI + "?group=test&version=1.0.0&method=GetUserByCode"
+	data := "{\"types\":\"int\",\"values\":1}"
+	s := post(t, url, data)
+	assert.True(t, strings.Contains(s, "0001"))
+}

--- a/integrate_test.sh
+++ b/integrate_test.sh
@@ -24,6 +24,15 @@ fi
 P_DIR=$(pwd)/$1
 PIXIU_DIR=$(pwd)
 
+if [ "$(basename $P_DIR)" = "https" ]; then
+  trap 'docker compose -f "$P_DIR/docker/docker-compose.yml" down' EXIT
+  docker compose -f "$P_DIR/docker/docker-compose.yml" up -d || exit 1
+  sleep 2
+
+  make PROJECT_DIR=$P_DIR PIXIU_DIR=$PIXIU_DIR PROJECT_NAME=$(basename $P_DIR) BASE_DIR=$P_DIR/dist -f igt/Makefile integration
+  exit $?
+fi
+
 # prepare
 make PROJECT_DIR=$P_DIR PIXIU_DIR=$PIXIU_DIR PROJECT_NAME=$(basename $P_DIR) BASE_DIR=$P_DIR/dist -f igt/Makefile prepare
 

--- a/start_integrate_test.sh
+++ b/start_integrate_test.sh
@@ -33,6 +33,8 @@ array=(
   # http
   "http/grpc"
   "http/simple"
+  # https
+  "https"
   # grpc proxy
   "grpc/deprecated"
   "grpc/reflection"


### PR DESCRIPTION
**What this PR does**:

Completes the `https` Pixiu sample as a runnable and verifiable HTTPS -> Pixiu -> Dubbo provider -> Zookeeper chain.

Aligned with the expected behavior described in the issue, this PR:

- Aligns the cluster referenced by `conf.yaml` routes with the cluster defined in `conf.yaml`:
  - Uses `test_dubbo` for both `route.cluster` and `clusters[].name`.

- Aligns the Dubbo integration `clusterName` in `api_config.yaml` with the Pixiu cluster config:
  - Keeps `clusterName` as `test_dubbo`.
  - Makes it match the Pixiu cluster defined in `conf.yaml`.

- Builds a clear main path across the HTTPS listener, API resource path, Dubbo integration, and Zookeeper registry:
  - Updates the API path to `/api/v1/test-dubbo/:interface` (aligned with the new http->dubbo configuration style in `dubbo-go-pixiu`: the legacy `opt.application` mapping has been removed from Dubbo sample options; `dubbogo/simple/proxy` was also migrated to the same path shape in 4374696).
  - Switches the HTTPS sample from a static endpoint to Zookeeper-based Dubbo service discovery.
  - Adds a Dubbo provider that registers `com.dubbogo.pixiu.UserService`.
  - Uses Docker Compose to start Pixiu, the Dubbo provider, Zookeeper, and the local certificate initialization task together.

- Adds a verifiable entry point to prove that HTTPS requests can reach the Dubbo provider:
  - Adds an HTTPS request script.
  - Adds an integration test.
  - Adds an `integrate_test.sh https` path that starts Docker Compose and runs the HTTPS integration test.

**Which issue(s) this PR fixes**:

Fixes #147

**Special notes for your reviewer**:

- This sample runs Pixiu in Docker instead of starting it directly on the host. Pixiu v1.1.0 uses autocert for the HTTPS listener and binds the standard HTTPS port `443`. Since `443` is a privileged port on macOS/Linux, a normal user process cannot reliably bind it in local or CI environments. The sample therefore lets Pixiu listen on `443` inside the container and maps it to host port `8443`.

- This sample also avoids relying on real ACME certificate issuance. ACME/autocert normally requires a publicly reachable domain and external validation, which is not suitable for a local sample. The Compose setup generates a self-signed certificate cache for `sample.domain.com` and mounts it into Pixiu's autocert cache directory. The test client and `request.sh` intentionally use insecure TLS verification for this local sample path.

- The Dubbo provider also runs inside Docker Compose. This keeps Pixiu, the provider, and Zookeeper on the same Docker network, so the provider address registered in Zookeeper is directly reachable by Pixiu. If the provider ran on the host while Pixiu ran in a container, the provider could register a host-local or otherwise unreachable address, causing Pixiu to discover the service but fail to connect.

**Does this PR introduce a user-facing change?**:

```release-note
Complete the HTTPS Pixiu Dubbo sample chain with Dockerized Pixiu, Dubbo provider, Zookeeper registry setup, and integration test.
```

