### PR TITLE
fix: add ReferenceGrant and fix backend image version

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -28,7 +28,7 @@ Install the required CRDs from the project root:
 
 ```sh
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
-kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=develop'
+kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=v1.1.0'
 ```
 
 ## How to Run

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,97 @@
+# Gateway Sample
+
+[中文](./README_CN.md)
+
+This sample demonstrates how to use Apache Dubbo-go-pixiu with Kubernetes
+Gateway API resources. It deploys a Pixiu Gateway data plane and routes HTTP
+requests to a Dubbo Triple helloworld backend.
+
+The example includes:
+
+- A Pixiu Gateway controller, `GatewayClass`, and `Gateway`.
+- A helloworld backend `Service` and `Deployment`.
+- An `HTTPRoute` that forwards requests to the backend service.
+- A `ReferenceGrant` that allows the cross-namespace backend reference.
+- Pixiu `PixiuClusterPolicy` and `PixiuFilterPolicy` resources for the gateway.
+
+## Prerequisites
+
+Before running this sample, ensure that you have:
+
+- A running Kubernetes cluster, such as minikube.
+- `kubectl` configured to access the cluster.
+- Gateway API CRDs v1.5.0 or later. This sample uses
+  `gateway.networking.k8s.io/v1` `ReferenceGrant`.
+- Pixiu CRDs for `PixiuClusterPolicy` and `PixiuFilterPolicy`.
+
+Install the required CRDs from the project root:
+
+```sh
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=develop'
+```
+
+## How to Run
+
+Run the following commands from the project root (`dubbo-go-pixiu-samples`).
+
+### 1. Deploy Pixiu Gateway
+
+```sh
+kubectl apply -f gateway/k8s/pixiu-gateway.yaml
+```
+
+This manifest creates the Pixiu Gateway controller, `GatewayClass`, and
+`Gateway` resources.
+
+### 2. Deploy the Helloworld Backend
+
+```sh
+kubectl apply -f gateway/helloworld/deployment.yaml
+```
+
+The backend service runs in the `helloworld` namespace and listens on port
+`20000`.
+
+### 3. Apply the HTTP Route and Pixiu Policies
+
+```sh
+kubectl apply -f gateway/http/http.yaml
+```
+
+This manifest creates the `HTTPRoute`, the `ReferenceGrant` in the `helloworld`
+namespace, and the Pixiu policies that target `Gateway default/pixiu`.
+
+### 4. Check the Resources
+
+```sh
+kubectl get pods -A
+kubectl get httproute -n default
+kubectl get referencegrant -n helloworld
+```
+
+You should see the Pixiu Gateway controller, the Pixiu data plane, and the
+helloworld backend pod running.
+
+### 5. Send a Request
+
+Forward the Pixiu data plane port:
+
+```sh
+kubectl port-forward -n default pod/<pixiu-pod-name> 8888:8888
+```
+
+Open another terminal and send a request:
+
+```sh
+curl -v \
+  -H 'Content-Type: application/json' \
+  --data '{"name":"Dubbo"}' \
+  http://127.0.0.1:8888/greet.GreetService/Greet
+```
+
+The response should look like:
+
+```json
+{"greeting":"Dubbo"}
+```

--- a/gateway/README_CN.md
+++ b/gateway/README_CN.md
@@ -26,7 +26,7 @@
 
 ```sh
 kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
-kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=develop'
+kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=v1.1.0'
 ```
 
 ## 如何运行

--- a/gateway/README_CN.md
+++ b/gateway/README_CN.md
@@ -1,0 +1,91 @@
+# Gateway 示例
+
+[English](./README.md)
+
+本示例演示了如何在 Kubernetes Gateway API 资源下使用 Apache Dubbo-go-pixiu。示例会部署 Pixiu Gateway 数据面，并将 HTTP 请求路由到 Dubbo Triple helloworld 后端服务。
+
+示例包括：
+
+- Pixiu Gateway 控制器、`GatewayClass` 和 `Gateway`。
+- helloworld 后端 `Service` 和 `Deployment`。
+- 将请求转发到后端服务的 `HTTPRoute`。
+- 允许跨 namespace backend 引用的 `ReferenceGrant`。
+- 作用于网关的 Pixiu `PixiuClusterPolicy` 和 `PixiuFilterPolicy` 资源。
+
+## 前置条件
+
+运行本示例前，请确保已经准备好：
+
+- 一个可用的 Kubernetes 集群，例如 minikube。
+- 已配置好访问该集群的 `kubectl`。
+- Gateway API CRD v1.5.0 或更高版本。本示例使用
+  `gateway.networking.k8s.io/v1` 的 `ReferenceGrant`。
+- Pixiu 的 `PixiuClusterPolicy` 和 `PixiuFilterPolicy` CRD。
+
+在项目根目录下安装所需 CRD：
+
+```sh
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=develop'
+```
+
+## 如何运行
+
+以下命令均在项目根目录 (`dubbo-go-pixiu-samples`) 下执行。
+
+### 1. 部署 Pixiu Gateway
+
+```sh
+kubectl apply -f gateway/k8s/pixiu-gateway.yaml
+```
+
+该 manifest 会创建 Pixiu Gateway 控制器、`GatewayClass` 和 `Gateway` 资源。
+
+### 2. 部署 Helloworld 后端服务
+
+```sh
+kubectl apply -f gateway/helloworld/deployment.yaml
+```
+
+后端服务运行在 `helloworld` namespace 中，并监听 `20000` 端口。
+
+### 3. 应用 HTTP 路由和 Pixiu Policy
+
+```sh
+kubectl apply -f gateway/http/http.yaml
+```
+
+该 manifest 会创建 `HTTPRoute`、位于 `helloworld` namespace 的 `ReferenceGrant`，以及作用于 `Gateway default/pixiu` 的 Pixiu policy。
+
+### 4. 检查资源
+
+```sh
+kubectl get pods -A
+kubectl get httproute -n default
+kubectl get referencegrant -n helloworld
+```
+
+你应该能看到 Pixiu Gateway 控制器、Pixiu 数据面和 helloworld 后端 Pod 都处于运行状态。
+
+### 5. 发送请求
+
+转发 Pixiu 数据面端口：
+
+```sh
+kubectl port-forward -n default pod/<pixiu-pod-name> 8888:8888
+```
+
+打开另一个终端并发送请求：
+
+```sh
+curl -v \
+  -H 'Content-Type: application/json' \
+  --data '{"name":"Dubbo"}' \
+  http://127.0.0.1:8888/greet.GreetService/Greet
+```
+
+预期响应如下：
+
+```json
+{"greeting":"Dubbo"}
+```

--- a/gateway/helloworld/deployment.yaml
+++ b/gateway/helloworld/deployment.yaml
@@ -40,6 +40,21 @@ spec:
   selector:
     app: dubbo-go-server
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-default-httproute-to-dubbo-go-server
+  namespace: helloworld
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: dubbo-go-server
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,7 +74,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: dubbogopixiu/helloworld-go-server:master
+          image: dubbogopixiu/helloworld-go-server@sha256:45de06f3c8df768a215b4228b87836157feb95b40ff93f321218d6131d4a457f
           imagePullPolicy: IfNotPresent
           ports:
             - name: triple

--- a/gateway/helloworld/deployment.yaml
+++ b/gateway/helloworld/deployment.yaml
@@ -40,21 +40,6 @@ spec:
   selector:
     app: dubbo-go-server
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: ReferenceGrant
-metadata:
-  name: allow-default-httproute-to-dubbo-go-server
-  namespace: helloworld
-spec:
-  from:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      namespace: default
-  to:
-    - group: ""
-      kind: Service
-      name: dubbo-go-server
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/gateway/helloworld/deployment.yaml
+++ b/gateway/helloworld/deployment.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: dubbogopixiu/helloworld-go-server@sha256:45de06f3c8df768a215b4228b87836157feb95b40ff93f321218d6131d4a457f
+          image: dubbogopixiu/helloworld-go-server:master
           imagePullPolicy: IfNotPresent
           ports:
             - name: triple

--- a/gateway/http/http.yaml
+++ b/gateway/http/http.yaml
@@ -39,6 +39,21 @@ spec:
           port: 20000
           weight: 100
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: allow-default-httproute-to-dubbo-go-server
+  namespace: helloworld
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: dubbo-go-server
+---
 apiVersion: pixiu.apache.org/v1alpha1
 kind: PixiuClusterPolicy
 metadata:


### PR DESCRIPTION
**What this PR does**:

This PR fixes the reproducibility issue caused by the floating `master` image tag in the `gateway` sample, as well as the missing authorization for the cross-namespace backend reference:

- Updates the helloworld backend image in `gateway/helloworld/deployment.yaml` from the floating tag `dubbogopixiu/helloworld-go-server:master` to a fixed image digest, so the sample result is no longer affected by `master` tag drift.
- Adds a `ReferenceGrant` in `gateway/helloworld/deployment.yaml` to allow the `HTTPRoute` in the `default` namespace to reference the `dubbo-go-server` Service in the `helloworld` namespace, completing the authorization required by Gateway API for cross-namespace `backendRef`.
- Keeps the sample reference graph closed:
  - `HTTPRoute` -> `Gateway default/pixiu`
  - `HTTPRoute` -> `Service helloworld/dubbo-go-server`
  - `ReferenceGrant` -> authorizes the cross-namespace Service reference above
  - `PixiuClusterPolicy` / `PixiuFilterPolicy` -> `Gateway default/pixiu`
  - `PixiuFilterPolicy` -> `helloworld-dubbo-go-server` cluster

- Verified locally with minikube that the sample resources can be accepted by Kubernetes, the Pixiu controller can create the data plane Pod, and requests can be forwarded through Pixiu to the helloworld backend.

```bash
# Verification commands
kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
kubectl apply -k 'https://github.com/apache/dubbo-go-pixiu/controllers/config/crd?ref=develop'

kubectl apply -f gateway/k8s/pixiu-gateway.yaml
kubectl apply -f gateway/helloworld/deployment.yaml
kubectl apply -f gateway/http/http.yaml

kubectl get pods -A
kubectl get httproute -n default
kubectl get referencegrant -n helloworld

# Request verification
kubectl port-forward -n default pod/<pixiu-pod-name> 8888:8888

curl -v \
  -H 'Content-Type: application/json' \
  --data '{"name":"Dubbo"}' \
  http://127.0.0.1:8888/greet.GreetService/Greet

# Response
{"greeting":"Dubbo"}
```

Fixes #146

**Does this PR introduce a user-facing change?**

```release-note
NONE
```