### PR TITLE
fix: Add warmup request body for health check

### DIFF
--- a/ai/kvcache/mock/run.sh
+++ b/ai/kvcache/mock/run.sh
@@ -45,6 +45,8 @@ PIXIU_PID=""
 
 REQ_BODY='{"model":"mock-model","messages":[{"role":"user","content":"please explain kv cache routing"}]}'
 
+WARMUP_BODY='{"model":"mock-model","messages":[{"role":"user","content":"warmup health check"}]}'
+
 cleanup() {
   set +e
   if [[ -n "${PIXIU_PID}" ]] && kill -0 "${PIXIU_PID}" >/dev/null 2>&1; then
@@ -95,7 +97,7 @@ wait_for_pixiu() {
     status="$(curl -s -o "${WORK_DIR}/kvcache-pixiu-ready.out" -w '%{http_code}' \
       -H 'Content-Type: application/json' \
       -X POST "${PIXIU_URL}/v1/chat/completions" \
-      -d "${REQ_BODY}" || true)"
+      -d "${WARMUP_BODY}" || true)"
     if [[ "${status}" == "200" || "${status}" == "4"* || "${status}" == "5"* ]]; then
       return 0
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

这个 PR 修复了 `ai/kvcache/mock` 示例中的测试失败问题，其中 `tokenize_calls >= 1` 断言失败，因为预热请求污染了缓存。

- 在 `ai/kvcache/mock/run.sh` 中为 Pixiu 探活请求新增专用的 `WARMUP_BODY`。
- 保持正式断言请求体不变，确保第一次正式请求仍会触发 tokenize，而不是命中探活请求提前写入的 token cache。
- 保留现有 mock stats reset 流程和断言逻辑；本次修复只隔离探活流量与业务验证流量。

**Verification**:

- 使用 `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go build -o /tmp/pixiu-bin ./cmd/pixiu` 从 `dubbo-go-pixiu` 构建 Pixiu，并安装到 `/usr/local/bin/pixiu` 供样例运行。
- `cd dubbo-go-pixiu-samples/ai/kvcache/mock && timeout 180 bash run.sh > /tmp/kvcache_mock_output2.log 2>&1; echo "EXIT=$?"` 返回 `EXIT=0`。
- `cd dubbo-go-pixiu-samples/ai/kvcache/real-engine && env GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache go test -v ./test/pixiu_test.go` 在未配置 `VLLM_ENDPOINT` / `LMCACHE_ENDPOINT` 时按预期跳过。


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #140 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```