### PR TITLE
fix: Update README with SAML client signature instructions and config

### DIFF
--- a/auth/saml/README.md
+++ b/auth/saml/README.md
@@ -110,6 +110,24 @@ http://localhost:18080/realms/pixiu/protocol/saml/descriptor
 
 This URL matches the `idp_metadata_url` used in `pixiu/conf.yaml`.
 
+### Disable `Client signature required` on the SAML client
+
+Keycloak's SAML clients default `Client signature required=ON`, which forces the SP to sign every AuthnRequest. Pixiu's SAML filter does not sign AuthnRequests, so leaving this on causes Keycloak to reject the redirect with `error="invalid_signature"` / `SigAlg was null`. Run the following from your host to toggle it off (Assertion / Response signing on the IdP side is kept on, so the SAML response is still cryptographically protected):
+
+```bash
+# Log in to kcadm inside the container
+docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080 --realm master --user admin --password admin
+
+# Resolve the SAML client's UUID
+CID=$(docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh get clients \
+    -r pixiu -q clientId=pixiu-saml-sp --fields id --format csv --noquotes 2>/dev/null | tr -d '\r')
+
+# Patch: keep IdP-side signing on, turn SP-side AuthnRequest signing off
+docker exec pixiu-saml-keycloak bash -c 'echo "{\"attributes\":{\"saml.server.signature\":\"true\",\"saml.assertion.signature\":\"true\",\"saml.client.signature\":\"false\"}}" > /tmp/patch.json'
+docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh update clients/$CID -r pixiu -f /tmp/patch.json
+```
+
 ## Step 3: Start the backend server
 
 ```bash

--- a/auth/saml/README.md
+++ b/auth/saml/README.md
@@ -112,7 +112,7 @@ This URL matches the `idp_metadata_url` used in `pixiu/conf.yaml`.
 
 ### Disable `Client signature required` on the SAML client
 
-Keycloak's SAML clients default `Client signature required=ON`, which forces the SP to sign every AuthnRequest. Pixiu's SAML filter does not sign AuthnRequests, so leaving this on causes Keycloak to reject the redirect with `error="invalid_signature"` / `SigAlg was null`. Run the following from your host to toggle it off (Assertion / Response signing on the IdP side is kept on, so the SAML response is still cryptographically protected):
+Keycloak's SAML clients default to `Client signature required=ON`, which forces the SP to sign every AuthnRequest. Pixiu's SAML filter does not sign AuthnRequests, so leaving this on causes Keycloak to reject the redirect with `error="invalid_signature"` / `SigAlg was null`. Run the following from your host to toggle it off (Assertion / Response signing on the IdP side is kept on, so the SAML response is still cryptographically protected):
 
 ```bash
 # Log in to kcadm inside the container

--- a/auth/saml/README_CN.md
+++ b/auth/saml/README_CN.md
@@ -109,6 +109,24 @@ http://localhost:18080/realms/pixiu/protocol/saml/descriptor
 
 这个地址与 `pixiu/conf.yaml` 中配置的 `idp_metadata_url` 一致。
 
+### 关闭 SAML Client 的 `Client signature required`
+
+Keycloak 创建 SAML client 时默认 `Client signature required=ON`，要求 SP 端给每个 AuthnRequest 签名。Pixiu 的 SAML filter 没有实现 AuthnRequest 签名，因此保留这一项会导致 Keycloak 拒绝跳转，日志报 `error="invalid_signature"` / `SigAlg was null`。在宿主机执行下面三步把它关掉即可（IdP→SP 方向的 Response / Assertion 签名保持开启，SAML 响应仍受签名保护）：
+
+```bash
+# 在容器内登录 kcadm
+docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080 --realm master --user admin --password admin
+
+# 查出 SAML client 的 UUID
+CID=$(docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh get clients \
+    -r pixiu -q clientId=pixiu-saml-sp --fields id --format csv --noquotes 2>/dev/null | tr -d '\r')
+
+# 提交 patch：保留 IdP 端签名，关闭 SP 端 AuthnRequest 签名
+docker exec pixiu-saml-keycloak bash -c 'echo "{\"attributes\":{\"saml.server.signature\":\"true\",\"saml.assertion.signature\":\"true\",\"saml.client.signature\":\"false\"}}" > /tmp/patch.json'
+docker exec pixiu-saml-keycloak /opt/keycloak/bin/kcadm.sh update clients/$CID -r pixiu -f /tmp/patch.json
+```
+
 ## 第 3 步：启动后端服务
 
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

这个 PR 修复了 `auth/saml` 示例按 README 配置后无法完成 Keycloak 登录的问题。Keycloak SAML client 默认要求 SP 对 AuthnRequest 签名，但当前 Pixiu SAML filter 不会生成该签名，导致 Keycloak 拒绝登录请求并报 `invalid_signature` / `SigAlg was null`。

- 在 README 中说明 Keycloak SAML client 默认要求 AuthnRequest 签名，而当前 Pixiu SAML filter 不会生成该签名。
- 在英文和中文 README 中补充 `kcadm.sh` 配置步骤，将 `saml.client.signature` 设为 `false`，同时保留 `saml.server.signature=true` 和 `saml.assertion.signature=true`，确保 IdP 到 SP 的 Response / Assertion 签名仍然开启。


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #141 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```