### PR TITLE
Fix dubbohttpproxy/server/http

### DIFF
--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -63,7 +63,12 @@ func user(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"message":"user not found"}`))
 		return
 	}
-	b, _ := json.Marshal(u)
+	b, err := json.Marshal(u)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
 	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
 	w.Write(b)
 }

--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -22,7 +22,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+)
 
+import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 )
 

--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -22,9 +22,7 @@ import (
 	"io"
 	"log"
 	"net/http"
-)
 
-import (
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
 )
 
@@ -45,8 +43,8 @@ func user(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(err.Error()))
 		return
 	}
-	// Pixiu 的 dgp.filter.dubbo.http 把 generic invocation 的实参数组整体
-	// json.Marshal 后发出，body 形如 ["0001"]，所以反序列化目标是 []string。
+	// Pixiu's dgp.filter.dubbo.http marshals generic invocation arguments as an array,
+	// so the request body is shaped like ["0001"] and should be decoded into []string.
 	var args []string
 	if err := json.Unmarshal(byts, &args); err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io"
 	"log"
-	"math/rand"
 	"net/http"
 )
 
@@ -36,41 +35,37 @@ func main() {
 }
 
 func user(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case constant.Post:
-		byts, err := io.ReadAll(r.Body)
-		if err != nil {
-			w.Write([]byte(err.Error()))
-		}
-		var name string
-		var user User
-		err = json.Unmarshal(byts, &name)
-		if err != nil {
-			w.Write([]byte(err.Error()))
-		}
-		_, ok := cache.Get(name)
-		if ok {
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
-			w.Write([]byte("{\"message\":\"data is exist\"}"))
-			return
-		}
-		user.ID = randSeq(5)
-		if cache.Add(&user) {
-			b, _ := json.Marshal(&user)
-			w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
-			w.Write(b)
-			return
-		}
-		w.Write(nil)
+	if r.Method != constant.Post {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
 	}
-}
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-func randSeq(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+	byts, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
 	}
-	return string(b)
+	// Pixiu 的 dgp.filter.dubbo.http 把 generic invocation 的实参数组整体
+	// json.Marshal 后发出，body 形如 ["0001"]，所以反序列化目标是 []string。
+	var args []string
+	if err := json.Unmarshal(byts, &args); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	if len(args) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("missing id argument"))
+		return
+	}
+	u, ok := cache.Get(args[0])
+	if !ok {
+		w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"user not found"}`))
+		return
+	}
+	b, _ := json.Marshal(u)
+	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
+	w.Write(b)
 }

--- a/dubbohttpproxy/server/http/server_test.go
+++ b/dubbohttpproxy/server/http/server_test.go
@@ -7,6 +7,12 @@
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package main

--- a/dubbohttpproxy/server/http/server_test.go
+++ b/dubbohttpproxy/server/http/server_test.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUserHandlerGetUserById(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/com.dubbogo.pixiu.TripleUserService/GetUserById",
+		strings.NewReader(`["0001"]`))
+	w := httptest.NewRecorder()
+	user(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"id":"0001"`) || !strings.Contains(body, `"name":"tc"`) {
+		t.Fatalf("expected id=0001 name=tc, got %s", body)
+	}
+}
+
+func TestUserHandlerNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/com.dubbogo.pixiu.TripleUserService/GetUserById",
+		strings.NewReader(`["9999"]`))
+	w := httptest.NewRecorder()
+	user(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "user not found") {
+		t.Fatalf("expected user not found body, got %s", w.Body.String())
+	}
+}
+
+func TestUserHandlerBadSchemaString(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/com.dubbogo.pixiu.TripleUserService/GetUserById",
+		strings.NewReader(`"0001"`))
+	w := httptest.NewRecorder()
+	user(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for plain-string body, got %d", w.Code)
+	}
+}
+
+func TestUserHandlerEmptyArray(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost,
+		"/com.dubbogo.pixiu.TripleUserService/GetUserById",
+		strings.NewReader(`[]`))
+	w := httptest.NewRecorder()
+	user(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty array, got %d body=%s", w.Code, w.Body.String())
+	}
+	b, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(b), "missing id argument") {
+		t.Fatalf("expected missing id argument, got %s", string(b))
+	}
+}
+
+func TestUserHandlerCacheNotPolluted(t *testing.T) {
+	before := len(cache.cacheMap)
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodPost,
+			"/com.dubbogo.pixiu.TripleUserService/GetUserById",
+			strings.NewReader(`["miss-`+string(rune('A'+i))+`"]`))
+		w := httptest.NewRecorder()
+		user(w, req)
+	}
+	after := len(cache.cacheMap)
+	if before != after {
+		t.Fatalf("cache size changed: before=%d after=%d", before, after)
+	}
+}
+
+func TestUserHandlerMethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet,
+		"/com.dubbogo.pixiu.TripleUserService/GetUserById", nil)
+	w := httptest.NewRecorder()
+	user(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}

--- a/dubbohttpproxy/server/http/user.go
+++ b/dubbohttpproxy/server/http/user.go
@@ -38,9 +38,9 @@ func init() {
 
 var cache *UserDB
 
-// UserDB cache user.
+// UserDB caches users by user ID.
 type UserDB struct {
-	// key is name, value is user obj
+	// key is user ID, value is user obj
 	cacheMap map[string]*User
 	lock     sync.Mutex
 }
@@ -54,12 +54,12 @@ func (db *UserDB) Add(u *User) bool {
 	return true
 }
 
-// Get returns the user.
-func (db *UserDB) Get(n string) (*User, bool) {
+// Get returns the user for the given user ID.
+func (db *UserDB) Get(id string) (*User, bool) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	r, ok := db.cacheMap[n]
+	r, ok := db.cacheMap[id]
 	return r, ok
 }
 

--- a/dubbohttpproxy/server/http/user.go
+++ b/dubbohttpproxy/server/http/user.go
@@ -50,7 +50,7 @@ func (db *UserDB) Add(u *User) bool {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	db.cacheMap[u.Name] = u
+	db.cacheMap[u.ID] = u
 	return true
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

这个 PR 修复了 `dubbohttpproxy/server/http` 示例中 Dubbo -> HTTP 转发链路的业务语义问题。此前 HTTP handler 期望请求体是 JSON 字符串，但 Pixiu 的 Dubbo generic 调用实际发送的是参数数组，例如 `["0001"]`，导致反序列化失败、错误信息被拼进响应 body，并且 miss 时会写入 `Name=""` 的错误 cache entry。

- 重写 `dubbohttpproxy/server/http` 的 `user()` handler，使其接受 Pixiu Dubbo generic 调用实际发送的参数数组 body（`["0001"]`）。
- 对非法 body、缺少参数、用户不存在和不支持的方法分别返回明确的 `400`、`404`、`405` 状态码，并保证所有错误路径都会提前 `return`。
- 删除 miss 时随机创建用户的逻辑，避免继续污染 `Name=""` 的 cache entry。
- 将 `UserDB.Add` 改为按用户 ID 写入 HTTP 样例缓存，使 `GetUserById("0001")` 返回预置的 `tc` 用户记录。
- 新增 `dubbohttpproxy/server/http/server_test.go`，覆盖成功查询、用户不存在、错误 schema、空参数、cache 不污染和不支持的方法。


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #143 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```