### PR TITLE
fix: handle invalid JSON and unsupported methods

### DIFF
--- a/http/simple/server/app/server.go
+++ b/http/simple/server/app/server.go
@@ -41,12 +41,14 @@ func user(w http.ResponseWriter, r *http.Request) {
 	case constant.Post:
 		byts, err := io.ReadAll(r.Body)
 		if err != nil {
-			w.Write([]byte(err.Error()))
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		var user User
 		err = json.Unmarshal(byts, &user)
 		if err != nil {
-			w.Write([]byte(err.Error()))
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		_, ok := cache.Get(user.Name)
 		if ok {
@@ -83,6 +85,10 @@ func user(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNotFound)
 		w.Write(nil)
+	default:
+		w.Header().Set("Allow", constant.Post+", "+constant.Get)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
 	}
 }
 

--- a/http/simple/test/pixiu_test.go
+++ b/http/simple/test/pixiu_test.go
@@ -55,13 +55,58 @@ func TestGET1(t *testing.T) {
 	req, err := http.NewRequest("GET", url, nil)
 	assert.NoError(t, err)
 	req.Header.Add("Origin", "api.dubbo.com")
-	req.Header.Add("Content-Type", "application/json")
 	resp, err := client.Do(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, 200, resp.StatusCode)
 	s, _ := io.ReadAll(resp.Body)
 	assert.True(t, strings.Contains(string(s), "0001"))
+	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
+	assert.Equal(t, "api.dubbo.com", ao)
+}
+
+func TestPut(t *testing.T) {
+	url := "http://localhost:8888/user/tc"
+	data := "{\"id\":\"0001\",\"name\":\"tc\",\"age\":20}"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("PUT", url, strings.NewReader(data))
+	assert.NoError(t, err)
+	req.Header.Add("Origin", "api.dubbo.com")
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 405, resp.StatusCode)
+	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
+	assert.Equal(t, "api.dubbo.com", ao)
+}
+
+func TestDelete(t *testing.T) {
+	url := "http://localhost:8888/user/tc"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("DELETE", url, nil)
+	assert.NoError(t, err)
+	req.Header.Add("Origin", "api.dubbo.com")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 405, resp.StatusCode)
+	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
+	assert.Equal(t, "api.dubbo.com", ao)
+}
+
+func TestPostInvalidJSON(t *testing.T) {
+	url := "http://localhost:8888/user/"
+	data := "{"
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest("POST", url, strings.NewReader(data))
+	assert.NoError(t, err)
+	req.Header.Add("Origin", "api.dubbo.com")
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 400, resp.StatusCode)
 	ao := resp.Header.Get(constant.HeaderKeyAccessControlAllowOrigin)
 	assert.Equal(t, "api.dubbo.com", ao)
 }


### PR DESCRIPTION
**What this PR does**:

Fixes an issue in the `http/simple` sample where invalid requests could be treated as successful requests:

- When `POST /user/` receives an invalid JSON request body, it now returns `400 Bad Request` immediately and stops further processing, avoiding writing a zero-value `User{Name:""}` into the cache.
- Adds a fallback branch for unsupported HTTP methods in the `/user/` handler, so unsupported methods such as `PUT` and `DELETE` return `405 Method Not Allowed` instead of the default `200 OK` empty response.
- Adds negative tests in `http/simple/test/pixiu_test.go` for invalid JSON, `PUT`, and `DELETE` scenarios to prevent regressions such as `2xx + error body` or `2xx + empty body`.

**Which issue(s) this PR fixes**:
Fixes #144

**Special notes for your reviewer**:

This PR only updates error handling and related tests for the `http/simple` sample. It does not change the successful `POST /user/` or `GET /user/{name}` behavior.

**Does this PR introduce a user-facing change?**:
```release-note
None