### PR TITLE
fix: add invalid JSON test and fix descriptor path

### DIFF
--- a/http/grpc/pixiu/conf.yaml
+++ b/http/grpc/pixiu/conf.yaml
@@ -40,7 +40,7 @@ static_resources:
                   - name: dgp.filter.http.grpcproxy
                     config:
                       descriptor_source_strategy: auto  # none, auto( invoke: ->reflection->file), local, remote  ## default: auto
-                      path: samples/http/grpc/pixiu/proto
+                      path: $PROJECT_DIR/proto
                 server_name: "test-http-grpc"
                 generate_request_id: false
       config:

--- a/http/grpc/test/pixiu_test.go
+++ b/http/grpc/test/pixiu_test.go
@@ -51,6 +51,7 @@ func TestGet(t *testing.T) {
 	assert.NotNil(t, body)
 	var r proto.GetUserResponse
 	err = json.Unmarshal(body, &r)
+	assert.Equal(t, 200, resp.StatusCode)
 	assert.NoError(t, err)
 	assert.Equal(t, "user(s) query successfully", r.Message)
 	assert.Equal(t, 2, len(r.Users))
@@ -71,9 +72,23 @@ func TestPost(t *testing.T) {
 	assert.NotNil(t, body)
 	var r proto.GetUserResponse
 	err = json.Unmarshal(body, &r)
+	assert.Equal(t, 200, resp.StatusCode)
 	assert.NoError(t, err)
 	assert.Equal(t, "user(s) query successfully", r.Message)
 	assert.Equal(t, 1, len(r.Users))
 	assert.Equal(t, int32(1), r.Users[0].UserId)
 	assert.Equal(t, "Kenway", r.Users[0].Name)
+}
+
+func TestPostInvalidJSON(t *testing.T) {
+	c := http.Client{Timeout: 5 * time.Second}
+	invalidData := "{"
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(invalidData))
+	assert.NoError(t, err)
+	resp, err := c.Do(req)
+	assert.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.NotNil(t, body)
+	assert.Equal(t, 502, resp.StatusCode)
 }


### PR DESCRIPTION
**What this PR does**:

- Fixes the grpcproxy descriptor path configuration in the `http/grpc` sample so it points to the actual proto directory, instead of the non-existent `samples/http/grpc/pixiu/proto`.

- Adds a negative test for invalid JSON request bodies in `http/grpc/test/pixiu_test.go`, verifying that grpcproxy returns `502 Bad Gateway` when HTTP JSON cannot be converted into a protobuf request, instead of continuing with a successful response.

**Which issue(s) this PR fixes**:
Fixes #145

**Special notes for your reviewer**:

This PR keeps the fix focused on two issues directly related to the `http/grpc` sample:

- Fix the descriptor path so the sample configuration matches the repository layout.
- Add an invalid JSON request test to cover the JSON -> protobuf conversion failure path.

This PR does not add assertions for `unsupported method`, `unknown path`, or `wrong service prefix` for the following reasons:

- In the `http -> grpc` scenario, the incoming HTTP method does not have a strict one-to-one mapping to the final gRPC method, so `unsupported method` is not clearly applicable here. gRPC is transported over HTTP/2 POST, and in this `http -> grpc` flow, `GET` / `POST` / `PUT` / `DELETE` HTTP requests may all call the same gRPC service as long as the URL resolves to the same service/method.
- For `unknown path` and `wrong service prefix`, I think the test scope is too broad and not necessary for this PR.
- (Please correct me if this understanding is wrong)

**Does this PR introduce a user-facing change?**:

```release-note
None