### PR TITLE
fix: resolve golangci-lint errcheck & format issues in dubbohttpproxy http server

### DIFF
--- a/dubbohttpproxy/server/http/server.go
+++ b/dubbohttpproxy/server/http/server.go
@@ -42,7 +42,7 @@ func user(w http.ResponseWriter, r *http.Request) {
 	byts, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 	// Pixiu's dgp.filter.dubbo.http marshals generic invocation arguments as an array,
@@ -50,27 +50,27 @@ func user(w http.ResponseWriter, r *http.Request) {
 	var args []string
 	if err := json.Unmarshal(byts, &args); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 	if len(args) == 0 {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("missing id argument"))
+		_, _ = w.Write([]byte("missing id argument"))
 		return
 	}
 	u, ok := cache.Get(args[0])
 	if !ok {
 		w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"message":"user not found"}`))
+		_, _ = w.Write([]byte(`{"message":"user not found"}`))
 		return
 	}
 	b, err := json.Marshal(u)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 	w.Header().Set(constant.HeaderKeyContextType, constant.HeaderValueJsonUtf8)
-	w.Write(b)
+	_, _ = w.Write(b)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
 Fix `golangci-lint errcheck` failure: explicitly ignore `w.Write()` return values with `_, _ = ` in all response paths of `dubbohttpproxy/server/http/server.go`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```